### PR TITLE
fix: change 'answer' vars names for 'result' in all relevant files

### DIFF
--- a/src/ex2_js-basics-part2/task-03.js
+++ b/src/ex2_js-basics-part2/task-03.js
@@ -1,15 +1,15 @@
 'use strict';
 
 function differElements(arr) {
-  let answer = [0, 0, 0];
+  let result = [0, 0, 0];
   for (let elem of arr) {
     if (typeof(elem) !== "number") {continue};
-    if (elem === 0) {answer[2]++;}
-    else if (elem % 2 === 0) {answer[0]++;}
-    else if (elem % 2 === 1) {answer[1]++;}
+    if (elem === 0) {result[2]++;}
+    else if (elem % 2 === 0) {result[0]++;}
+    else if (elem % 2 === 1) {result[1]++;}
   }
-  console.log(`Evens: ${answer[0]}, odds: ${answer[1]}, nulls: ${answer[2]}`);
-  return answer;
+  console.log(`Evens: ${result[0]}, odds: ${result[1]}, nulls: ${result[2]}`);
+  return result;
 }
 
 module.exports = differElements;

--- a/src/ex3_js-objects-part1/task-06.js
+++ b/src/ex3_js-objects-part1/task-06.js
@@ -2,25 +2,25 @@
 
 function deepClone(obj) {
   if (Array.isArray(obj)) {
-    let answer = [];
+    let result = [];
     for (let i of obj) {
       if (typeof(i) === 'object') {
-        answer.push(deepClone(i));
+        result.push(deepClone(i));
       }
-      else answer.push(i);
+      else result.push(i);
     }
-    return answer;
+    return result;
   }
-  let answer = {};
+  let result = {};
   for (let key in obj ) {
     if (typeof obj[key] === 'object') {
-      answer[key] = deepClone(obj[key]);
+      result[key] = deepClone(obj[key]);
     }
     else {
-      answer[key] = obj[key];
+      result[key] = obj[key];
     }
   }
-  return answer;  
+  return result;  
 }
 
 module.exports = deepClone;

--- a/src/ex6_js-array-methods/task-04.js
+++ b/src/ex6_js-array-methods/task-04.js
@@ -1,13 +1,13 @@
 'use strict'
 
 function filter(array, callback) {
-  let answer = [];
+  let result = [];
   for (let i = 0; i < array.length; i++) {
     if (callback(array[i], i, array)) {
-      answer.push(array[i]);
+      result.push(array[i]);
     }
   }
-  return answer;  
+  return result;  
 }
 
 module.exports = filter;

--- a/src/ex6_js-array-methods/task-05.js
+++ b/src/ex6_js-array-methods/task-05.js
@@ -1,11 +1,11 @@
 'use strict'
 
 function map(array, callback) {
-  let answer = [];
+  let result = [];
   for (let i = 0; i < array.length; i++) {
-    answer.push(callback(array[i], i, array));    
+    result.push(callback(array[i], i, array));    
   }
-  return answer;  
+  return result;  
 }
 
 module.exports = map;


### PR DESCRIPTION
В файлах уже сданных домашних заданий были названия переменных answer
Создал эту дополнительную ветку и заменил такие названия на result во всех файлах.
Предлагаю этот pull-request для того, чтобы в итоговом репозитории вообще нигде не было названий переменных answer